### PR TITLE
Melty Monster not being neutral to players on Strider

### DIFF
--- a/src/main/java/com/github/mechalopa/hmag/world/entity/MeltyMonsterEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/MeltyMonsterEntity.java
@@ -78,7 +78,7 @@ public class MeltyMonsterEntity extends Monster implements RangedAttackMob
 		this.goalSelector.addGoal(7, new RandomLookAroundGoal(this));
 		this.targetSelector.addGoal(1, new HurtByTargetGoal(this));
 		this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 10, true, false, (p) -> {
-			return !(p.getVehicle() != null && p.getType().is(ModTags.EntityTypeTags.MELTY_MONSTER_AVOID_MOBS));
+			return !(p.getVehicle() != null && p.getVehicle().getType().is(ModTags.EntityTypeTags.MELTY_MONSTER_AVOID_MOBS));
 		}));
 	}
 


### PR DESCRIPTION
When meeting a player riding a Strider, the Melty Monster will move away but still try shooting the player distantly.
The probable fix is in the pull request, but I didn't test if it fully fix this problem...