### PR TITLE
Changing `setVariant` to `protected`

### DIFF
--- a/src/main/java/com/github/mechalopa/hmag/world/entity/BansheeEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/BansheeEntity.java
@@ -142,7 +142,7 @@ public class BansheeEntity extends AbstractFlyingMonsterEntity implements IModMo
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int type)
+	protected void setVariant(int type)
 	{
 		if (type < 0 || type >= 2)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/CreeperGirlEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/CreeperGirlEntity.java
@@ -105,7 +105,8 @@ public class CreeperGirlEntity extends Creeper implements IModMob
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int typeIn)
+
+	protected void setVariant(int typeIn)
 	{
 		if (typeIn < 0 || typeIn >= 3)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/CursedDollEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/CursedDollEntity.java
@@ -185,7 +185,7 @@ public class CursedDollEntity extends Monster implements IModMob
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int type)
+	protected void setVariant(int type)
 	{
 		if (type < 0 || type >= 2)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/GhostEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/GhostEntity.java
@@ -172,7 +172,7 @@ public class GhostEntity extends AbstractFlyingMonsterEntity implements IModMob
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int typeIn)
+	protected void setVariant(int typeIn)
 	{
 		if (typeIn < 0 || typeIn >= 5)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/HarpyEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/HarpyEntity.java
@@ -188,7 +188,7 @@ public class HarpyEntity extends Monster implements IModMob
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int typeIn)
+	protected void setVariant(int typeIn)
 	{
 		if (typeIn < 0 || typeIn >= 7)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/KashaEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/KashaEntity.java
@@ -192,7 +192,7 @@ public class KashaEntity extends Monster implements IModMob
 		return KashaEntity.Variant.byId(this.entityData.get(DATA_VARIANT_ID));
 	}
 
-	private void setVariant(KashaEntity.Variant variant)
+	protected void setVariant(KashaEntity.Variant variant)
 	{
 		if (!this.level.isClientSide)
 		{

--- a/src/main/java/com/github/mechalopa/hmag/world/entity/SlimeGirlEntity.java
+++ b/src/main/java/com/github/mechalopa/hmag/world/entity/SlimeGirlEntity.java
@@ -283,7 +283,7 @@ public class SlimeGirlEntity extends Monster implements IModMob
 		return this.entityData.get(DATA_VARIANT_ID);
 	}
 
-	private void setVariant(int typeIn)
+	protected void setVariant(int typeIn)
 	{
 		if (typeIn < 0 || typeIn >= SlimeGirlEntity.ColorVariant.values().length)
 		{


### PR DESCRIPTION
Some mobs in my mod extend this mod's classes and need to call `setVariant`. Now I have to use reflection to call it because it's `private`. If possible, could you change it to `protected`?