### PR TITLE
A possible fix to JEI smithing upgrade showing wrong output in #35

### DIFF
--- a/src/main/java/com/github/mechalopa/hmag/compat/JEIPlugin.java
+++ b/src/main/java/com/github/mechalopa/hmag/compat/JEIPlugin.java
@@ -22,9 +22,11 @@ import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -195,7 +197,7 @@ public class JEIPlugin implements IModPlugin
 
 	private static void addSmithingRecipe(List<SmithingRecipe> smithingRecipes, ResourceLocation id, Ingredient template, Ingredient base, Ingredient addition, ItemStack output)
 	{
-		smithingRecipes.add(new SmithingTransformRecipe(id, template, base, addition, output));
+		smithingRecipes.add(new FixedOutputSmithingTransformRecipe(id, template, base, addition, output));
 	}
 
 	private static ItemStack getEnchantableItemStack(IRecipeRegistration registration, List<Item> list, Enchantment enchantment, TagKey<Item> blacklist)
@@ -221,5 +223,17 @@ public class JEIPlugin implements IModPlugin
 		}
 
 		return ItemStack.EMPTY;
+	}
+
+	private static final class FixedOutputSmithingTransformRecipe extends SmithingTransformRecipe {
+
+		public FixedOutputSmithingTransformRecipe(ResourceLocation p_267143_, Ingredient p_266750_, Ingredient p_266787_, Ingredient p_267292_, ItemStack p_267031_) {
+			super(p_267143_, p_266750_, p_266787_, p_267292_, p_267031_);
+		}
+
+		@Override
+		public ItemStack assemble(Container p_267036_, RegistryAccess p_266699_) {
+			return this.getResultItem(p_266699_);
+		}
 	}
 }


### PR DESCRIPTION
I did some digging around and before, JEI used to call Recipe#getResultItem in [this commit](https://github.com/mezz/JustEnoughItems/blob/a695e5ee5ebb31e76d32e8956e43020b83e51285/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/SmithingRecipeCategory.java#L86). Later it was changed to Recipe#assemble in response to 2 other smithing related bugs ([#3640](https://github.com/mezz/JustEnoughItems/issues/3640) and [#3639](https://github.com/mezz/JustEnoughItems/issues/3693)) [here](https://github.com/mezz/JustEnoughItems/blob/91322ccf008a31554856131172ee47720bf2dc27/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/SmithingRecipeCategory.java#L91), which resolves to [this empty extension implementation](https://github.com/mezz/JustEnoughItems/blob/77f54fbc4ac2298f458106710586d5fc727e148f/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/SmithingTransformCategoryExtension.java) which defaults back to [this](https://github.com/mezz/JustEnoughItems/blob/91322ccf008a31554856131172ee47720bf2dc27/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/SmithingCategoryExtension.java#L52). The [RecipeUtil](https://github.com/mezz/JustEnoughItems/blob/1.20.1/Library/src/main/java/mezz/jei/library/util/RecipeUtil.java) class calls those 2 Recipe methods under the hood.

![SmithingTransformRecipe](https://github.com/user-attachments/assets/0d703d48-7b92-4ed3-b596-c7f6ed0e3bd9) The SmithingTransformRecipe implementation of the assemble method shows the NBT data being copied over to the result ItemStack while getResultItem does not have this behavior.

I tested on JEI 15.20.0.104, which is a version I'm using in a modded playthrough and where #35 occurs. JEI does show the correct output ItemStack with the fix.
![2025-02-12_18 45 38](https://github.com/user-attachments/assets/f8de367d-fff0-46c1-8351-5ff17e2125ba)
![2025-02-12_18 45 54](https://github.com/user-attachments/assets/10a92ec0-fb70-4887-b438-b059baede54f)
So far everything else seems to be fine, but you can check again since I did not check every possible interaction.
![2025-02-12_19 00 19](https://github.com/user-attachments/assets/ad7d6f37-3eef-47f5-8319-0d562c0dae10)
![2025-02-12_19 00 36](https://github.com/user-attachments/assets/6beec29f-a8c1-40ff-b139-4912c571c176)

I did not include the change in JEI version in gradle.properties in this commit, so you can change it to whatever suits you. It's also fine to close this PR without merging, I don't think my code is that good and there are probably better ways to do this. It's more to explore why the bug happened and one possible solution.





